### PR TITLE
enable cross build by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ scalaVersion := "2.12.4"
 
 crossScalaVersions := Seq("2.11.6", scalaVersion.value)
 
+ReleaseKeys.crossBuild := true
+
 unmanagedResourceDirectories in Compile += baseDirectory.value / "conf"
 
 scmInfo := Some(ScmInfo(


### PR DESCRIPTION
the previous version would only build for scala 2.12 unless it was released by running "sbt release cross".
This setting is supposed to release 2.11 and 2.12 by default. 