### PR TITLE
Wraparound emergency tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 project/project
 project/target
+.idea

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 This library was mainly created to share [some code on content-authorisation](https://github.com/guardian/content-authorisation/blob/afe5bd36364cde229d0bc03d6f1ca61bfc1f64c0/content-authorisation/src/main/scala/com/gu/authorisation/provider/GeneratedTokens.scala) so it can be reused elsewhere.
+
+To build locally type publishLocal, but if you need scala 2.11 version do
+```
+++ 2.11.12
+publishLocal
+```

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ organization := "com.gu"
 
 scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.11.6", scalaVersion.value)
+crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 
 ReleaseKeys.crossBuild := true
 

--- a/src/test/scala/com/gu/cas/TokenPayloadTest.scala
+++ b/src/test/scala/com/gu/cas/TokenPayloadTest.scala
@@ -34,4 +34,14 @@ class TokenPayloadTest extends FlatSpec with Matchers {
 
   }
 
+  "create token payload" should "be created if it's still in the first era" in {
+    val payload = TokenPayload(epoch.plusDays(100))(Weeks.THREE, SevenDay)
+    payload.creationDateOffset should be(Days.days(100))
+  }
+
+  "create token payload" should "be created if it's into the second era" in {
+    val payload = TokenPayload(wrappedEpoch.plusDays(100))(Weeks.THREE, SevenDay)
+    payload.creationDateOffset should be(Days.days(100))
+  }
+
 }

--- a/src/test/scala/com/gu/cas/TokenPayloadTest.scala
+++ b/src/test/scala/com/gu/cas/TokenPayloadTest.scala
@@ -1,0 +1,37 @@
+package com.gu.cas
+
+import org.joda.time.{Days, Weeks}
+import org.scalatest.{FlatSpec, Matchers}
+
+class TokenPayloadTest extends FlatSpec with Matchers {
+
+  val epoch = TokenPayload.epoch.toLocalDate
+  val wrappedEpoch = epoch.plusDays(2048)
+  val startOffset = 2040
+  val testData = TokenPayload(Days.days(startOffset), Weeks.weeks(2), SevenDay)
+
+  "Token Payload" should "return the end date on the issue date (with no wrapping)" in {
+
+    testData.expiryDate(epoch.plusDays(startOffset)) should be(epoch.plusDays(startOffset + 14 + 1))
+
+  }
+
+  "Token Payload" should "return the expiry date on expiry date (with no wrapping)" in {
+
+    testData.expiryDate(epoch.plusDays(startOffset + 14 + 1)) should be(epoch.plusDays(startOffset + 14 + 1))
+
+  }
+
+  "Token Payload" should "work on the day before the wrapped creation date (with no wrapping)" in {
+
+    testData.expiryDate(wrappedEpoch.plusDays(startOffset - 1)) should be(epoch.plusDays(startOffset + 14 + 1))
+
+  }
+
+  "Token Payload" should "return the wrapped expiry date on the wrapped creation date" in {
+
+    testData.expiryDate(wrappedEpoch.plusDays(startOffset)) should be(wrappedEpoch.plusDays(startOffset + 14 + 1))
+
+  }
+
+}


### PR DESCRIPTION
Suddenly we were getting errors that 2048 doesn't fit in 11 bits when running the cas emergency token provider.  After a bit of investigation, we realised that we had fallen foul of a [5 year limitation on some old code](https://github.com/guardian/content-authorisation/commit/8d4e9d9aa14b43997b5d62a5a2f42dbc4ebc2cec#diff-9414c88106ab88ec9ce46d53534fbc78R35)! 😆   After the laughter died down we thought of a couple of solutions, perhaps make a different prefix to indicate a new era (G98, G97 etc), or use a new prefix to indicate a change of format e.g. more bits for the date.  We were conscious of the desirability to keep the length of the token the same.  The other option was just to make the dates wrap around, so tokens issues would be valid for their period once again every 2048 days.

In the end I decided the least invasive/extra complexity option was to make them wrap around, and the small chance that people will get free stuff if they save the tokens long enough was not a big issue.
@pvighi @paulbrown1982 @jacobwinch @rtyley 