### PR TITLE
update commons-io for snyk and scala/sbt/other deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,16 @@ import ReleaseStateTransformations._
 name := "content-authorisation-common"
 description := "Extracts some behaviours from content-authorisation"
 organization := "com.gu"
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.14"
 
-crossScalaVersions := Seq("2.11.8", scalaVersion.value, "2.13.3")
+crossScalaVersions := Seq(scalaVersion.value, "2.13.6")
 unmanagedResourceDirectories in Compile += baseDirectory.value / "conf"
-resolvers += "Guardian Github Releases" at "http://guardian.github.io/maven/repo-releases"
+resolvers += "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases"
 
 libraryDependencies ++= Seq(
-  "commons-io" % "commons-io" % "2.4",
-  "joda-time" % "joda-time" % "2.9.1",
-  "com.typesafe" % "config" % "1.3.0",
+  "commons-io" % "commons-io" % "2.11.0",
+  "joda-time" % "joda-time" % "2.10.10",
+  "com.typesafe" % "config" % "1.4.1",
   "org.scalatest" %% "scalatest" % "3.1.1" % "test"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.5

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6-SNAPSHOT"
+version in ThisBuild := "0.6"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6"
+version in ThisBuild := "0.7-SNAPSHOT"


### PR DESCRIPTION
neeeded for subs frontend and CAS lambda
This PR bumps commons-io to get a non vulnerable version

  ✗ Directory Traversal [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109] in commons-io:commons-io@2.6
    introduced by com.gu:content-authorisation-common_2.12@0.5 > commons-io:commons-io@2.6
  This issue was fixed in versions: 2.7

