### PR TITLE
Set Java distribution for action

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
+        distribution: adopt
         java-version: 11
       
     - name: Run tests


### PR DESCRIPTION
In v2 of the `setup-java` action, the 'distribution` property is required.
See https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md
